### PR TITLE
Install the arm64 binary if we are on an arm64 macOS

### DIFF
--- a/install.js
+++ b/install.js
@@ -8,6 +8,7 @@ const pkg = require('./package');
 const { DownloaderHelper } = require('node-downloader-helper');
 const { promisify } = require('util');
 const tar = require('tar');
+const semver = require('semver');
 const unlink = promisify(fs.unlink);
 const mkdir = promisify(fs.mkdir);
 const chmod = promisify(fs.chmod);
@@ -42,7 +43,13 @@ function getDriverUrl() {
 
   switch (os.platform()) {
     case 'darwin':
-      return `${urlBase}geckodriver-${GECKODRIVER_VERSION}-macos.tar.gz`;
+      // Starting from Geckodriver v0.29.1, there is a separate build for arm64
+      // architecture. Let's install it if we are on arm64 as well.
+      const arch =
+        os.arch() === 'arm64' && semver.gte(GECKODRIVER_VERSION, '0.29.1')
+          ? '-aarch64'
+          : '';
+      return `${urlBase}geckodriver-${GECKODRIVER_VERSION}-macos${arch}.tar.gz`;
     case 'linux': {
       if (os.arch() === 'arm') {
         // Don't want to spend hours to build a new one, so for now serve 0.29.0


### PR DESCRIPTION
Hi @soulgalore!

Browsertime was failing to capture Firefox Profiler profiles with the "power" profiling feature enabled on my and @mrchrisadams's machines. After doing some debugging, I realized that it's because of the geckodriver binary we had. We are still using the x86_64 binary in arm64 machines and Marionette protocol was throwing some errors with this feature enabled. After switching to arm64 binary, I can confirm that the issue is fixed. 

Here's a command to reproduce:
```
./bin/browsertime.js https://sitespeed.io -b firefox --firefox.geckoProfiler --firefox.geckoProfilerParams.features "power" -n 1
```
This was failing on arm64. I also tested on x84_64 macbooks and it doesn't fail there. When I manually update the `sitespeedio/geckodriver` dependency to use this branch, the issue gets fixed.

Also, this came up from the discussions in https://github.com/sitespeedio/sitespeed.io/issues/3944