### PR TITLE
Install correct geckodriver binary on arm64 Linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,9 +8,12 @@ on:
     - main
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.arch.runner }}
     strategy:
       matrix:
+        arch:
+          - { platform: amd64, runner: ubuntu-24.04 }
+          - { platform: arm64, runner: ubuntu-24.04-arm }
         node-version: [22.x]
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -20,3 +23,5 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Install
       run: npm ci
+    - name: Verify downloaded driver runs on ${{ matrix.arch.platform }}
+      run: npm test

--- a/install.js
+++ b/install.js
@@ -53,6 +53,9 @@ function getDriverUrl() {
         // or unreleased 0.30.0
         return `${urlBase}geckodriver-0.30.0-linux-arm.tar.gz`;
       }
+      if (os.arch() === 'arm64') {
+        return `${urlBase}geckodriver-${GECKODRIVER_VERSION}-linux-aarch64.tar.gz`;
+      }
       const arch = os.arch() === 'x64' ? '64' : '32';
       return `${urlBase}geckodriver-${GECKODRIVER_VERSION}-linux${arch}.tar.gz`;
     }


### PR DESCRIPTION
  On arm64 Linux, install.js silently fell through to the x86 fallback and
  downloaded the 32-bit Linux build. That binary then failed at runtime
  with "Exec format error", which surfaced downstream as selenium
  reporting "Server terminated early with status 2" — the kind of error
  that's hard to trace back here. arm64 Linux runners are increasingly
  common (CI on GitHub-hosted arm64, sitespeed.io's multi-arch container),
  so it's worth handling explicitly the same way the darwin branch
  already does.

  The Linux CI workflow also only ran npm ci and never executed the
  downloaded driver, which is why this slipped through. Adding npm test
  plus an arm64 runner to the matrix verifies the installed binary
  actually runs.

  Co-authored-by: Claude noreply@anthropic.com